### PR TITLE
Added support to parse RAML from a string instead of a file

### DIFF
--- a/test/ParseTest.php
+++ b/test/ParseTest.php
@@ -16,6 +16,52 @@ class ParseTest extends PHPUnit_Framework_TestCase
     // ---
 
     /** @test */
+    public function shouldCorrectlyLoadASimpleRamlString()
+    {
+        $raml = <<<RAML
+#%RAML 0.8
+title: ZEncoder API
+documentation:
+ - title: Home
+   content: |
+     Welcome to the _Zencoder API_ Documentation. The _Zencoder API_
+     allows you to connect your application to our encoding service
+     and encode videos without going through the web  interface. You
+     may also benefit from one of our
+     [integration libraries](https://app.zencoder.com/docs/faq/basics/libraries)
+     for different languages.
+version: v2
+baseUri: https://app.zencoder.com/api/{version}
+RAML;
+
+        $simpleRaml = $this->parser->parseFromString($raml, '');
+        $docList = $simpleRaml->getDocumentationList();
+
+        $this->assertEquals('ZEncoder API', $simpleRaml->getTitle());
+        $this->assertEquals('Home', $docList[0]['title']);
+        $this->assertEquals('v2', $simpleRaml->getVersion());
+    }
+
+    /** @test */
+    public function shouldCorrectlyLoadASimpleRamlStringWithInclude()
+    {
+        $raml = <<<RAML
+#%RAML 0.8
+title: ZEncoder API
+documentation: !include child.raml
+version: v2
+baseUri: https://app.zencoder.com/api/{version}
+RAML;
+
+        $simpleRaml = $this->parser->parseFromString($raml, __DIR__ . '/fixture');
+        $docList = $simpleRaml->getDocumentationList();
+
+        $this->assertEquals('ZEncoder API', $simpleRaml->getTitle());
+        $this->assertEquals('Home', $docList['title']);
+        $this->assertEquals('v2', $simpleRaml->getVersion());
+    }
+
+    /** @test */
     public function shouldCorrectlyLoadASimpleRamlFile()
     {
         $simpleRaml = $this->parser->parse(__DIR__.'/fixture/simple.raml');


### PR DESCRIPTION
Hey Alex,

This is a follow up to https://github.com/alecsammon/php-raml-parser/issues/46.
I thought about this again and found that the providers look nice at first sight but simply add additional complexity with no real gain.

This PR introduces a new method `parseFromString()` which lets you then decide where your content is coming from on your own if you like.

Moreover, I read the RAML spec once again regarding the `!include`. Because we'd need some sort of support for includes via an arbitrary provider too if we added this content provider thing (which makes it even more complex) and it says 

> The YAML specification does not require that YAML parsers use any particular mechanism for splitting a YAML file into smaller manageable pieces. However, RAML documents MUST be able to be split among multiple files. To support this function, all RAML parsers MUST support the include tag, which enables including RAML and YAML and regular text files.

So the __Parser__ is responsible of how to handle includes. Your class is already named `Parser` which indicates that when you want to do something different, you should just write your own parser class or extend this one and override parts of it (which is why this PR also includes the `private` --> `protected` change for `parseYaml()`).
