### PR TITLE
SymfonyRouteFormatter minor update

### DIFF
--- a/src/ApiDefinition.php
+++ b/src/ApiDefinition.php
@@ -234,6 +234,15 @@ class ApiDefinition
         return $this->schemas;
     }
 
+    /**
+     * @return array
+     */
+    public function getProtocols()
+    {
+        return $this->protocols;
+    }
+
+
     // ---
 
     /**
@@ -311,8 +320,8 @@ class ApiDefinition
     /**
      * Recursive function that generates a flat array of the entire API Definition
      *
-     * GET /songs => [/songs, GET, Raml\Method]
-     * GET /songs/{songId} => [/songs/{songId}, GET, Raml\Method]
+     * GET /songs => [api.example.org, /songs, GET, [https], Raml\Method]
+     * GET /songs/{songId} => [api.example.org, /songs/{songId}, GET, [https], Raml\Method]
      *
      * @param array $resources
      * @param string $path
@@ -321,8 +330,9 @@ class ApiDefinition
      */
     private function getResourcesAsArray(array $resources)
     {
-        $host = $this->getBaseUri();
         $all = [];
+        $baseUri = $this->getBaseUri();
+        $protocols = $this->protocols;
 
         // Loop over each resource to build out the full URI's that it has.
         foreach ($resources as $resource) {
@@ -330,8 +340,9 @@ class ApiDefinition
 
             foreach ($resource->getMethods() as $method) {
                 $all[$method->getType() . ' ' . $path] = [
-                    'host' => $host,
+                    'baseUri' => $baseUri,
                     'path' => $path,
+                    'protocols' => $protocols,
                     'method' => $method->getType(),
                     'response' => $resource->getMethod($method->getType())
                 ];

--- a/src/ApiDefinition.php
+++ b/src/ApiDefinition.php
@@ -321,6 +321,7 @@ class ApiDefinition
      */
     private function getResourcesAsArray(array $resources)
     {
+        $host = $this->getBaseUri();
         $all = [];
 
         // Loop over each resource to build out the full URI's that it has.
@@ -329,6 +330,7 @@ class ApiDefinition
 
             foreach ($resource->getMethods() as $method) {
                 $all[$method->getType() . ' ' . $path] = [
+                    'host' => $host,
                     'path' => $path,
                     'method' => $method->getType(),
                     'response' => $resource->getMethod($method->getType())

--- a/src/Formatters/SymfonyRouteFormatter.php
+++ b/src/Formatters/SymfonyRouteFormatter.php
@@ -55,6 +55,7 @@ class SymfonyRouteFormatter implements RouteFormatterInterface
 
             $route = new Route($path);
             $route->setMethods($resource['method']);
+            $route->setHost($resource['host']);
 
             $this->routes->add($resource['method'] . ' ' . $path, $route);
         }

--- a/src/Formatters/SymfonyRouteFormatter.php
+++ b/src/Formatters/SymfonyRouteFormatter.php
@@ -51,11 +51,23 @@ class SymfonyRouteFormatter implements RouteFormatterInterface
     public function format(array $resources)
     {
         foreach ($resources as $path => $resource) {
-            $path = ($this->addTrailingSlash) ? $resource['path'] . '/' : $resource['path'];
+            // This is the path from the RAML, with or without a /.
+            $path = $resource['path'] . ($this->addTrailingSlash ? '/' : '');
 
-            $route = new Route($path);
+            // This is the baseUri + path, the complete URL.
+            $url = $resource['baseUri'] . $path;
+
+            // Now remove the host away, so we have the FULL path to the resource.
+            // baseUri may also contain path that has been omitted for brevity in the
+            // RAML creation.
+            $host = parse_url($url, PHP_URL_HOST);
+            $fullPath = substr($url, strpos($url, $host) + strlen($host));
+
+            // Now build our Route class.
+
+            $route = new Route($fullPath);
             $route->setMethods($resource['method']);
-            $route->setHost($resource['host']);
+            $route->setSchemes($resource['protocols']);
 
             $this->routes->add($resource['method'] . ' ' . $path, $route);
         }

--- a/test/ApiDefinitionTest.php
+++ b/test/ApiDefinitionTest.php
@@ -59,6 +59,6 @@ class ApiDefinitionTest extends PHPUnit_Framework_TestCase
         $this->assertCount(4, $routeFormatter->getRoutes());
         $this->assertInstanceOf('\Symfony\Component\Routing\RouteCollection', $routeFormatter->getRoutes());
         $this->assertInstanceOf('\Symfony\Component\Routing\Route', $routeFormatter->getRoutes()->get('GET /songs/'));
-        $this->assertEquals('http://example.api.com/v1', $routeFormatter->getRoutes()->get('GET /songs/')->getHost());
+        $this->assertEquals(['http'], $routeFormatter->getRoutes()->get('GET /songs/')->getSchemes());
     }
 }

--- a/test/ApiDefinitionTest.php
+++ b/test/ApiDefinitionTest.php
@@ -59,5 +59,6 @@ class ApiDefinitionTest extends PHPUnit_Framework_TestCase
         $this->assertCount(4, $routeFormatter->getRoutes());
         $this->assertInstanceOf('\Symfony\Component\Routing\RouteCollection', $routeFormatter->getRoutes());
         $this->assertInstanceOf('\Symfony\Component\Routing\Route', $routeFormatter->getRoutes()->get('GET /songs/'));
+        $this->assertEquals('http://example.api.com/v1', $routeFormatter->getRoutes()->get('GET /songs/')->getHost());
     }
 }

--- a/test/ParseTest.php
+++ b/test/ParseTest.php
@@ -147,6 +147,8 @@ class ParseTest extends PHPUnit_Framework_TestCase
         $method = $resource->getMethod('get');
         $response = $method->getResponse(200);
 
+        $this->assertEquals(['application/json', 'application/xml'], $response->getTypes());
+
         $schema = $response->getExampleByType('application/json');
 
         $this->assertEquals([


### PR DESCRIPTION
This PR adds the host to the routes returned in the Symfony RouteCollection by using the `getBaseUri()`. This is useful if the Api Definition makes use of the named parameter, `{version}` (which will be replaced accordingly).

Also includes a tiny addition to a test case for a little extra coverage.