### PR TITLE
[1.0.1] Fixes issue #64

### DIFF
--- a/src/NamedParameter.php
+++ b/src/NamedParameter.php
@@ -386,11 +386,14 @@ class NamedParameter implements ArrayInstantiationInterface
     /**
      * Get the pattern regular expression
      *
+     * @param boolean $typeCheck Set to false to only return the "pattern" value from the RAML data (Defaults to
+     *                           true for backwards compatability to return type checking strings when a validation
+     *                           pattern is not present in the RAML data)
      * @return string
      */
-    public function getValidationPattern()
+    public function getValidationPattern($typeCheck = true)
     {
-        if ($this->validationPattern) {
+        if ($this->validationPattern || $typeCheck === false) {
             $pattern = $this->validationPattern;
         } else {
             switch($this->getType()) {

--- a/test/NamedParameters/ParameterTypesTest.php
+++ b/test/NamedParameters/ParameterTypesTest.php
@@ -178,6 +178,34 @@ RAML;
 
     // ---
     /** @test */
+    public function shouldIgnoreTypeCheckValidation()
+    {
+        $raml =  <<<RAML
+#%RAML 0.8
+title: Test named parameters
+/:
+  post:
+    body:
+      application/x-www-form-urlencoded:
+        formParameters:
+          param:
+            type: string
+            default: abcde
+RAML;
+
+        $apiDefinition = $this->parser->parseFromString($raml, '');
+        $resource = $apiDefinition->getResourceByUri('/');
+        $method = $resource->getMethod('post');
+        $body = $method->getBodyByType('application/x-www-form-urlencoded');
+
+        $namedParameter = $body->getParameter('param');
+        $this->assertEquals('string', $namedParameter->getType());
+        $this->assertEquals('abcde', $namedParameter->getDefault());
+        $this->assertEquals(null, $namedParameter->getValidationPattern(false));
+    }
+
+    // ---
+    /** @test */
     public function shouldParseCustomValidation()
     {
         $raml =  <<<RAML


### PR DESCRIPTION
Now devs can check the RAML supplied "pattern" value separately.