### PR TITLE
[1.3.1] Bug fix for multiple methods with custom settings

### DIFF
--- a/src/ApiDefinition.php
+++ b/src/ApiDefinition.php
@@ -140,7 +140,7 @@ class ApiDefinition implements ArrayInstantiationInterface
      *
      * @var bool
      */
-    private $merge_security = true;
+    private $mergeSecurity = true;
 
     // ---
 
@@ -174,13 +174,13 @@ class ApiDefinition implements ArrayInstantiationInterface
      *
      * @return ApiDefinition
      */
-    public static function createFromArray($title, array $data = [], $merge_security = true)
+    public static function createFromArray($title, array $data = [], $mergeSecurity = true)
     {
         $apiDefinition = new static($title);
 
         // --
 
-        $apiDefinition->merge_security = $merge_security;
+        $apiDefinition->mergeSecurity = $mergeSecurity;
 
         if (isset($data['version'])) {
             $apiDefinition->setVersion($data['version']);
@@ -671,8 +671,8 @@ class ApiDefinition implements ArrayInstantiationInterface
      *
      * @return boolean
      */
-    public function get_merge_security()
+    public function getMergeSecurity()
     {
-        return $this->merge_security;
+        return $this->mergeSecurity;
     }
 }

--- a/src/ApiDefinition.php
+++ b/src/ApiDefinition.php
@@ -627,10 +627,10 @@ class ApiDefinition implements ArrayInstantiationInterface
                     $scheme->setSettings($settings);
                      
                 }
+            
+                $schemeName = $schemeKey;
                 
             }
-            
-            $schemeName = $schemeKey;
             
         }
         

--- a/src/ApiDefinition.php
+++ b/src/ApiDefinition.php
@@ -132,6 +132,15 @@ class ApiDefinition implements ArrayInstantiationInterface
      * @var SecurityScheme[]
      */
     private $securedBy = [];
+    
+    /**
+     * Should security scheme structures merge with methods implementing the schemes?
+     *
+     * @TODO Change to false in version 2.0.0
+     *
+     * @var bool
+     */
+    private $merge_security = true;
 
     // ---
 
@@ -165,12 +174,13 @@ class ApiDefinition implements ArrayInstantiationInterface
      *
      * @return ApiDefinition
      */
-    public static function createFromArray($title, array $data = [])
+    public static function createFromArray($title, array $data = [], $merge_security = true)
     {
         $apiDefinition = new static($title);
 
         // --
 
+        $apiDefinition->merge_security = $merge_security;
 
         if (isset($data['version'])) {
             $apiDefinition->setVersion($data['version']);
@@ -654,5 +664,15 @@ class ApiDefinition implements ArrayInstantiationInterface
         }
 
         return $all;
+    }
+    
+    /**
+     * Check if security schemes must be merged with methods when the method uses securedBy
+     *
+     * @return boolean
+     */
+    public function get_merge_security()
+    {
+        return $this->merge_security;
     }
 }

--- a/src/ApiDefinition.php
+++ b/src/ApiDefinition.php
@@ -597,6 +597,7 @@ class ApiDefinition implements ArrayInstantiationInterface
     public function getSecurityScheme($schemeName)
     {
         if (is_array($schemeName) && count($schemeName) === 1) {
+            reset($schemeName);
             $schemeKey = key($schemeName);
             
             if (!empty($schemeName[$schemeKey]) &&
@@ -627,10 +628,10 @@ class ApiDefinition implements ArrayInstantiationInterface
                     $scheme->setSettings($settings);
                      
                 }
-            
-                $schemeName = $schemeKey;
                 
             }
+            
+            $schemeName = $schemeKey;
             
         }
         

--- a/src/Method.php
+++ b/src/Method.php
@@ -189,10 +189,17 @@ class Method implements ArrayInstantiationInterface
 
         if (isset($data['securedBy'])) {
             foreach ($data['securedBy'] as $securedBy) {
-                $method->addSecurityScheme(
-                    $apiDefinition->getSecurityScheme($securedBy),
-                    $apiDefinition->get_merge_security()
-                );
+                if ($securedBy) {
+                    $method->addSecurityScheme(
+                        $apiDefinition->getSecurityScheme($securedBy),
+                        $apiDefinition->get_merge_security()
+                    );
+                } else {
+                    $method->addSecurityScheme(
+                        SecurityScheme::createFromArray('null', [], $apiDefinition),
+                        $apiDefinition->get_merge_security()
+                    );
+                }
             }
         }
 

--- a/src/Method.php
+++ b/src/Method.php
@@ -192,12 +192,12 @@ class Method implements ArrayInstantiationInterface
                 if ($securedBy) {
                     $method->addSecurityScheme(
                         $apiDefinition->getSecurityScheme($securedBy),
-                        $apiDefinition->get_merge_security()
+                        $apiDefinition->getMergeSecurity()
                     );
                 } else {
                     $method->addSecurityScheme(
                         SecurityScheme::createFromArray('null', [], $apiDefinition),
-                        $apiDefinition->get_merge_security()
+                        $apiDefinition->getMergeSecurity()
                     );
                 }
             }

--- a/src/Method.php
+++ b/src/Method.php
@@ -188,12 +188,11 @@ class Method implements ArrayInstantiationInterface
         }
 
         if (isset($data['securedBy'])) {
-            foreach ($data['securedBy'] as $key => $securedBy) {
-                if ($securedBy) {
-                    $method->addSecurityScheme($apiDefinition->getSecurityScheme($securedBy));
-                } else {
-                    $method->addSecurityScheme(SecurityScheme::createFromArray('null', array(), $apiDefinition));
-                }
+            foreach ($data['securedBy'] as $securedBy) {
+                $method->addSecurityScheme(
+                    $apiDefinition->getSecurityScheme($securedBy),
+                    $apiDefinition->get_merge_security()
+                );
             }
         }
 
@@ -447,39 +446,42 @@ class Method implements ArrayInstantiationInterface
 
     /**
      * @param SecurityScheme $securityScheme
+     * @param bool $merge Set to true to merge the security scheme data with the method, or false to not merge it.
      */
-    public function addSecurityScheme(SecurityScheme $securityScheme)
+    public function addSecurityScheme(SecurityScheme $securityScheme, $merge = true)
     {
         $this->securitySchemes[$securityScheme->getKey()] = $securityScheme;
 
-        $describedBy = $securityScheme->getDescribedBy();
-        if ($describedBy) {
-            foreach ($describedBy->getHeaders() as $header) {
-                $this->addHeader($header);
-            }
-
-            foreach ($describedBy->getResponses() as $response) {
-                $this->addResponse($response);
-            }
-
-            foreach ($describedBy->getQueryParameters() as $queryParameter) {
-                $this->addQueryParameter($queryParameter);
-            }
-
-            foreach ($this->getBodies() as $bodyType => $body) {
-                if (in_array($bodyType, array_keys($describedBy->getBodies())) &&
-                    in_array($bodyType, WebFormBody::$validMediaTypes)
-                ) {
-                    $params = $describedBy->getBodyByType($bodyType)->getParameters();
-
-                    foreach ($params as $parameterName => $namedParameter) {
-                        $body->addParameter($namedParameter);
-                    }
+        if ($merge === true) {
+            $describedBy = $securityScheme->getDescribedBy();
+            if ($describedBy) {
+                foreach ($describedBy->getHeaders() as $header) {
+                    $this->addHeader($header);
                 }
-
-                $this->addBody($body);
+            
+                foreach ($describedBy->getResponses() as $response) {
+                    $this->addResponse($response);
+                }
+            
+                foreach ($describedBy->getQueryParameters() as $queryParameter) {
+                    $this->addQueryParameter($queryParameter);
+                }
+            
+                foreach ($this->getBodies() as $bodyType => $body) {
+                    if (in_array($bodyType, array_keys($describedBy->getBodies())) &&
+                        in_array($bodyType, WebFormBody::$validMediaTypes)
+                    ) {
+                        $params = $describedBy->getBodyByType($bodyType)->getParameters();
+            
+                        foreach ($params as $parameterName => $namedParameter) {
+                            $body->addParameter($namedParameter);
+                        }
+                    }
+            
+                    $this->addBody($body);
+                }
+            
             }
-
         }
     }
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -62,6 +62,15 @@ class Parser
      * @var boolean
      */
     private $allowDirectoryTraversal = true;
+    
+    /**
+     * Should security scheme structures merge with methods implementing the schemes?
+     *
+     * @TODO Change to false in version 2.0.0
+     *
+     * @var bool
+     */
+    private $merge_security = true;
 
     // ---
 
@@ -131,6 +140,27 @@ class Parser
     public function allowDirectoryTraversal()
     {
         $this->allowDirectoryTraversal = true;
+    }
+    
+    /**
+     * Choose whether or not to merge security schemes with the method's data when using securedBy
+     *
+     * @param bool $merge_security True to enable merging, or false to disable merging (Function
+     *                             default is false, script default is true)
+     */
+    public function set_merge_security($merge_security = false)
+    {
+        $this->merge_security = $merge_security;
+    }
+    
+    /**
+     * Check if security schemes must be merged with methods when the method uses securedBy
+     *
+     * @return boolean
+     */
+    public function get_merge_security()
+    {
+        return $this->merge_security;
     }
 
     /**
@@ -268,7 +298,7 @@ class Parser
             $ramlData['securitySchemes'] = $this->parseSecuritySettings($ramlData['securitySchemes']);
         }
 
-        return ApiDefinition::createFromArray($ramlData['title'], $ramlData);
+        return ApiDefinition::createFromArray($ramlData['title'], $ramlData, $this->merge_security);
     }
 
     /**

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -70,7 +70,7 @@ class Parser
      *
      * @var bool
      */
-    private $merge_security = true;
+    private $mergeSecurity = true;
 
     // ---
 
@@ -145,12 +145,12 @@ class Parser
     /**
      * Choose whether or not to merge security schemes with the method's data when using securedBy
      *
-     * @param bool $merge_security True to enable merging, or false to disable merging (Function
+     * @param bool $mergeSecurity True to enable merging, or false to disable merging (Function
      *                             default is false, script default is true)
      */
-    public function set_merge_security($merge_security = false)
+    public function setMergeSecurity($mergeSecurity = false)
     {
-        $this->merge_security = $merge_security;
+        $this->mergeSecurity = $mergeSecurity;
     }
     
     /**
@@ -158,9 +158,9 @@ class Parser
      *
      * @return boolean
      */
-    public function get_merge_security()
+    public function getMergeSecurity()
     {
-        return $this->merge_security;
+        return $this->mergeSecurity;
     }
 
     /**
@@ -298,7 +298,7 @@ class Parser
             $ramlData['securitySchemes'] = $this->parseSecuritySettings($ramlData['securitySchemes']);
         }
 
-        return ApiDefinition::createFromArray($ramlData['title'], $ramlData, $this->merge_security);
+        return ApiDefinition::createFromArray($ramlData['title'], $ramlData, $this->mergeSecurity);
     }
 
     /**

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -69,6 +69,13 @@ class Resource implements ArrayInstantiationInterface
      */
     private $methods = [];
 
+    /**
+     * A list of security schemes
+     *
+     * @var SecurityScheme[]
+     */
+    private $securitySchemes = [];
+
     // ---
 
     /**

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -137,6 +137,12 @@ class Resource implements ArrayInstantiationInterface
             }
         }
 
+        if (isset($data['securedBy'])) {
+            foreach ($data['securedBy'] as $securedBy) {
+                $resource->addSecurityScheme($apiDefinition->getSecurityScheme($securedBy));
+            }
+        }
+
         foreach ($data as $key => $value) {
             if (strpos($key, '/') === 0) {
                 $resource->addResource(
@@ -355,5 +361,25 @@ class Resource implements ArrayInstantiationInterface
         }
 
         return $this->methods[$method];
+    }
+
+    // --
+
+    /**
+     * Get the list of security schemes
+     *
+     * @return SecurityScheme[]
+     */
+    public function getSecuritySchemes()
+    {
+        return $this->securitySchemes;
+    }
+
+    /**
+     * @param SecurityScheme $securityScheme
+     */
+    public function addSecurityScheme(SecurityScheme $securityScheme)
+    {
+        $this->securitySchemes[$securityScheme->getKey()] = $securityScheme;
     }
 }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -139,7 +139,11 @@ class Resource implements ArrayInstantiationInterface
 
         if (isset($data['securedBy'])) {
             foreach ($data['securedBy'] as $securedBy) {
-                $resource->addSecurityScheme($apiDefinition->getSecurityScheme($securedBy));
+                if ($securedBy) {
+                    $resource->addSecurityScheme($apiDefinition->getSecurityScheme($securedBy));
+                } else {
+                    $resource->addSecurityScheme(SecurityScheme::createFromArray('null', [], $apiDefinition));
+                }
             }
         }
 

--- a/src/SecurityScheme/SecuritySettings/OAuth1SecuritySettings.php
+++ b/src/SecurityScheme/SecuritySettings/OAuth1SecuritySettings.php
@@ -9,27 +9,23 @@ class OAuth1SecuritySettings
     // --
 
     /**
-     * The URI of the Temporary Credential Request endpoint as defined in RFC5849 Section 2.1
-     *
-     * @var string
+     * The array of settings data
+     * @var array
      */
-    private $requestTokenUri;
-
-    /**
-     * The URI of the Resource Owner Authorization endpoint as defined in RFC5849 Section 2.2
-     *
-     * @var string
-     */
-    private $authorizationUri;
-
-    /**
-     * The URI of the Token Request endpoint as defined in RFC5849 Section 2.3
-     *
-     * @var string
-     */
-    private $tokenCredentialsUri;
+    private $settings;
 
     // ---
+    
+    /**
+     * Flesh out the settings
+     *
+     * @param array $settings
+     */
+    public function createFromArray(array $settings)
+    {
+        $defaults = array_fill_keys(array('tokenCredentialsUri', 'requestTokenUri', 'authorizationUri'), null);
+        $this->settings = array_replace($defaults, $settings);
+    }
 
     /**
      * Get the Token Credentials URI
@@ -38,7 +34,7 @@ class OAuth1SecuritySettings
      */
     public function getTokenCredentialsUri()
     {
-        return $this->tokenCredentialsUri;
+        return $this->settings['tokenCredentialsUri'];
     }
 
     /**
@@ -48,7 +44,7 @@ class OAuth1SecuritySettings
      */
     public function setTokenCredentialsUri($tokenCredentialsUri)
     {
-        $this->tokenCredentialsUri = $tokenCredentialsUri;
+        $this->settings['tokenCredentialsUri'] = $tokenCredentialsUri;
     }
 
     // --
@@ -60,7 +56,7 @@ class OAuth1SecuritySettings
      */
     public function getRequestTokenUri()
     {
-        return $this->requestTokenUri;
+        return $this->settings['requestTokenUri'];
     }
 
     /**
@@ -70,7 +66,7 @@ class OAuth1SecuritySettings
      */
     public function setRequestTokenUri($requestTokenUri)
     {
-        $this->requestTokenUri = $requestTokenUri;
+        $this->settings['requestTokenUri'] = $requestTokenUri;
     }
 
     // --
@@ -82,7 +78,7 @@ class OAuth1SecuritySettings
      */
     public function getAuthorizationUri()
     {
-        return $this->authorizationUri;
+        return $this->settings['authorizationUri'];
     }
 
     /**
@@ -92,6 +88,18 @@ class OAuth1SecuritySettings
      */
     public function setAuthorizationUri($authorizationUri)
     {
-        $this->authorizationUri = $authorizationUri;
+        $this->settings['authorizationUri'] = $authorizationUri;
+    }
+    
+    // --
+    
+    /**
+     * Get the array of configured settings
+     *
+     * @return array The array of settings data
+     */
+    public function getSettings()
+    {
+        return $this->settings;
     }
 }

--- a/src/SecurityScheme/SecuritySettings/OAuth2SecuritySettings.php
+++ b/src/SecurityScheme/SecuritySettings/OAuth2SecuritySettings.php
@@ -7,37 +7,25 @@ class OAuth2SecuritySettings
     const TYPE = 'OAuth 2.0';
 
     // --
-
+    
     /**
-     * The URI of the Authorization Endpoint as defined in RFC6749 [RFC6748] Section 3.1
-     *
-     * @var string
+     * The array of settings data
+     * @var array
      */
-    private $authorizationUri;
-
-    /**
-     * The URI of the Token Endpoint as defined in RFC6749 [RFC6748] Section 3.2
-     *
-     * @var string
-     */
-    private $accessTokenUri;
-
-    /**
-     * A list of the Authorization grants supported by the API As defined in RFC6749 [RFC6749]
-     * Sections 4.1, 4.2, 4.3 and 4.4, can be any of: code, token, owner or credentials.
-     *
-     * @var string[]
-     */
-    private $authorizationGrants;
-
-    /**
-     * A list of scopes supported by the API as defined in RFC6749 [RFC6749] Section 3.3
-     *
-     * @var string[]
-     */
-    private $scopes;
+    private $settings;
 
     // ---
+    
+    /**
+     * Flesh out the settings
+     *
+     * @param array $settings
+     */
+    public function createFromArray(array $settings)
+    {
+        $defaults = array_fill_keys(array('authorizationUri', 'accessTokenUri', 'authorizationGrants', 'scopes'), null);
+        $this->settings = array_replace($defaults, $settings);
+    }
 
     /**
      * Get the Authorization URI
@@ -46,7 +34,7 @@ class OAuth2SecuritySettings
      */
     public function getAuthorizationUri()
     {
-        return $this->authorizationUri;
+        return $this->settings['authorizationUri'];
     }
 
     /**
@@ -56,7 +44,7 @@ class OAuth2SecuritySettings
      */
     public function setAuthorizationUri($authorizationUri)
     {
-        $this->authorizationUri = $authorizationUri;
+        $this->settings['authorizationUri'] = $authorizationUri;
     }
 
     // --
@@ -68,7 +56,7 @@ class OAuth2SecuritySettings
      */
     public function getAccessTokenUri()
     {
-        return $this->accessTokenUri;
+        return $this->settings['accessTokenUri'];
     }
 
     /**
@@ -78,7 +66,7 @@ class OAuth2SecuritySettings
      */
     public function setAccessTokenUri($accessTokenUri)
     {
-        $this->accessTokenUri = $accessTokenUri;
+        $this->settings['accessTokenUri'] = $accessTokenUri;
     }
 
     // --
@@ -90,7 +78,7 @@ class OAuth2SecuritySettings
      */
     public function getAuthorizationGrants()
     {
-        return $this->authorizationGrants;
+        return $this->settings['authorizationGrants'];
     }
 
     /**
@@ -100,7 +88,7 @@ class OAuth2SecuritySettings
      */
     public function addAuthorizationGrants($authorizationGrant)
     {
-        $this->authorizationGrants[] = $authorizationGrant;
+        $this->settings['authorizationGrants'][] = $authorizationGrant;
     }
 
     // --
@@ -112,7 +100,7 @@ class OAuth2SecuritySettings
      */
     public function getScopes()
     {
-        return $this->scopes;
+        return $this->settings['scopes'];
     }
 
     /**
@@ -122,6 +110,18 @@ class OAuth2SecuritySettings
      */
     public function addScope($scope)
     {
-        $this->scopes[] = $scope;
+        $this->settings['scopes'][] = $scope;
+    }
+    
+    // --
+    
+    /**
+     * Get the array of configured settings
+     *
+     * @return array The array of settings data
+     */
+    public function getSettings()
+    {
+        return $this->settings;
     }
 }

--- a/src/SecurityScheme/SecuritySettingsParser/OAuth1SecuritySettingsParser.php
+++ b/src/SecurityScheme/SecuritySettingsParser/OAuth1SecuritySettingsParser.php
@@ -26,17 +26,7 @@ class OAuth1SecuritySettingsParser implements SecuritySettingsParserInterface
     {
         $securitySetting = new OAuth1SecuritySettings();
 
-        if (isset($data['requestTokenUri'])) {
-            $securitySetting->setRequestTokenUri($data['requestTokenUri']);
-        }
-
-        if (isset($data['authorizationUri'])) {
-            $securitySetting->setAuthorizationUri($data['authorizationUri']);
-        }
-
-        if (isset($data['tokenCredentialsUri'])) {
-            $securitySetting->setTokenCredentialsUri($data['tokenCredentialsUri']);
-        }
+        $securitySetting->createFromArray($data);
 
         return $securitySetting;
     }

--- a/src/SecurityScheme/SecuritySettingsParser/OAuth2SecuritySettingsParser.php
+++ b/src/SecurityScheme/SecuritySettingsParser/OAuth2SecuritySettingsParser.php
@@ -28,25 +28,7 @@ class OAuth2SecuritySettingsParser implements SecuritySettingsParserInterface
     {
         $securitySetting = new OAuth2SecuritySettings();
 
-        if (isset($data['authorizationUri'])) {
-            $securitySetting->setAuthorizationUri($data['authorizationUri']);
-        }
-
-        if (isset($data['accessTokenUri'])) {
-            $securitySetting->setAccessTokenUri($data['accessTokenUri']);
-        }
-
-        if (isset($data['authorizationGrants'])) {
-            foreach ($data['authorizationGrants'] as $authorizationGrant) {
-                $securitySetting->addAuthorizationGrants($authorizationGrant);
-            }
-        }
-
-        if (isset($data['scopes'])) {
-            foreach ($data['scopes'] as $scope) {
-                $securitySetting->addScope($scope);
-            }
-        }
+        $securitySetting->createFromArray($data);
 
         return $securitySetting;
     }

--- a/test/ParseTest.php
+++ b/test/ParseTest.php
@@ -815,4 +815,26 @@ RAML;
         $schemes = $resource->getSecuritySchemes();
         $this->assertFalse(empty($schemes['oauth_2_0']));
     }
+    
+    /** @test */
+    public function shouldParseCustomSettingsOnResource()
+    {
+        $apiDefinition = $this->parser->parse(__DIR__ . '/fixture/securedByCustomProps.raml');
+        $resource = $apiDefinition->getResourceByUri('/test');
+        $schemes = $resource->getSecuritySchemes();
+        $settings = $schemes['custom']->getSettings();
+        $this->assertSame($settings['myKey'], 'heLikesItNotSoMuch');
+    }
+    
+    /** @test */
+    public function shouldParseCustomSettingsOnMethodWithOAuthParser()
+    {
+        $apiDefinition = $this->parser->parse(__DIR__ . '/fixture/securedByCustomProps.raml');
+        $resource = $apiDefinition->getResourceByUri('/users');
+        $method = $resource->getMethod('get');
+        $schemes = $method->getSecuritySchemes();
+        $settingsObject = $schemes['oauth_2_0']->getSettings();
+        $settingsArray = $settingsObject->getSettings();
+        $this->assertSame($settingsArray['scopes'], array('ADMINISTRATOR'));
+    }
 }

--- a/test/ParseTest.php
+++ b/test/ParseTest.php
@@ -796,7 +796,7 @@ RAML;
     /** @test */
     public function shouldNotMergeMethodSecurityScheme()
     {
-        $this->parser->set_merge_security();
+        $this->parser->setMergeSecurity();
         $apiDefinition = $this->parser->parse(__DIR__ . '/fixture/securitySchemes.raml');
         $resource = $apiDefinition->getResourceByUri('/users');
         $method = $resource->getMethod('get');
@@ -804,7 +804,7 @@ RAML;
         $this->assertTrue(empty($headers['Authorization']));
         
         // Reset the value.
-        $this->parser->set_merge_security(true);
+        $this->parser->setMergeSecurity(true);
     }
     
     /** @test */

--- a/test/ParseTest.php
+++ b/test/ParseTest.php
@@ -648,9 +648,20 @@ RAML;
         $settings->setAuthorizationUri('https://www.dropbox.com/1/oauth/authorize');
         $settings->setTokenCredentialsUri('https://api.dropbox.com/1/oauth/access_token');
 
+        // Get the settings array and remove the key used for internal processing.
+        $oauthSettings = $securitySchemes['oauth_1_0']->getSettings()->getSettings();
+        unset($oauthSettings['_PRP_ORIGINAL_SETTINGS_']);
+        
+        // Make the settings data an array.
+        $settings = (array) $settings;
+        reset($settings);
+        
+        // Loose the class name key.
+        $settings = $settings[key($settings)];
+        
         $this->assertEquals(
             $settings,
-            $securitySchemes['oauth_1_0']->getSettings()
+            $oauthSettings
         );
 
     }
@@ -830,11 +841,11 @@ RAML;
     public function shouldParseCustomSettingsOnMethodWithOAuthParser()
     {
         $apiDefinition = $this->parser->parse(__DIR__ . '/fixture/securedByCustomProps.raml');
-        $resource = $apiDefinition->getResourceByUri('/users');
+        $resource = $apiDefinition->getResourceByUri('/test');
         $method = $resource->getMethod('get');
         $schemes = $method->getSecuritySchemes();
         $settingsObject = $schemes['oauth_2_0']->getSettings();
         $settingsArray = $settingsObject->getSettings();
-        $this->assertSame($settingsArray['scopes'], array('ADMINISTRATOR'));
+        $this->assertSame($settingsArray['scopes'], array('ADMINISTRATOR', 'USER'));
     }
 }

--- a/test/ParseTest.php
+++ b/test/ParseTest.php
@@ -782,4 +782,37 @@ RAML;
         $body = $response->getBodyByType('text/xml');
         $this->assertEquals('A generic description', $body->getDescription());
     }
+    
+    /** @test */
+    public function shouldMergeMethodSecurityScheme()
+    {
+        $apiDefinition = $this->parser->parse(__DIR__ . '/fixture/securitySchemes.raml');
+        $resource = $apiDefinition->getResourceByUri('/users');
+        $method = $resource->getMethod('get');
+        $headers = $method->getHeaders();
+        $this->assertFalse(empty($headers['Authorization']));
+    }
+    
+    /** @test */
+    public function shouldNotMergeMethodSecurityScheme()
+    {
+        $this->parser->set_merge_security();
+        $apiDefinition = $this->parser->parse(__DIR__ . '/fixture/securitySchemes.raml');
+        $resource = $apiDefinition->getResourceByUri('/users');
+        $method = $resource->getMethod('get');
+        $headers = $method->getHeaders();
+        $this->assertTrue(empty($headers['Authorization']));
+        
+        // Reset the value.
+        $this->parser->set_merge_security(true);
+    }
+    
+    /** @test */
+    public function shouldAddSecuritySchemeToResource()
+    {
+        $apiDefinition = $this->parser->parse(__DIR__ . '/fixture/resourceSecuritySchemes.raml');
+        $resource = $apiDefinition->getResourceByUri('/users');
+        $schemes = $resource->getSecuritySchemes();
+        $this->assertFalse(empty($schemes['oauth_2_0']));
+    }
 }

--- a/test/fixture/resourceSecuritySchemes.raml
+++ b/test/fixture/resourceSecuritySchemes.raml
@@ -1,0 +1,50 @@
+#%RAML 0.8
+title: Dropbox API
+version: 1
+baseUri: https://api.dropbox.com/{version}
+securitySchemes:
+    oauth_2_0:
+        description: |
+            Dropbox supports OAuth 2.0 for authenticating all API requests.
+        type: OAuth 2.0
+        describedBy:
+            headers:
+                Authorization:
+                    description: |
+                       Used to send a valid OAuth 2 access token. Do not use
+                       with the "access_token" query string parameter.
+                    type: string
+            queryParameters:
+                access_token:
+                    description: |
+                       Used to send a valid OAuth 2 access token. Do not use together with
+                       the "Authorization" header
+                    type: string
+            responses:
+                401:
+                    description: |
+                        Bad or expired token. This can happen if the user or Dropbox
+                        revoked or expired an access token. To fix, you should re-
+                        authenticate the user.
+                403:
+                    description: |
+                        Bad OAuth request (wrong consumer key, bad nonce, expired
+                        timestamp...). Unfortunately, re-authenticating the user won't help here.
+        settings:
+          authorizationUri: https://www.dropbox.com/1/oauth2/authorize
+          accessTokenUri: https://api.dropbox.com/1/oauth2/token
+          authorizationGrants: [ code, token ]
+    oauth_1_0:
+        description: |
+            OAuth 1.0 continues to be supported for all API requests, but OAuth 2.0 is now preferred.
+        type: OAuth 1.0
+        settings:
+          requestTokenUri: https://api.dropbox.com/1/oauth/request_token
+          authorizationUri: https://www.dropbox.com/1/oauth/authorize
+          tokenCredentialsUri: https://api.dropbox.com/1/oauth/access_token
+    customHeader:
+        description: |
+            A custom
+
+/users:
+    securedBy: [oauth_2_0, oauth_1_0]

--- a/test/fixture/resourceSecuritySchemes.raml
+++ b/test/fixture/resourceSecuritySchemes.raml
@@ -47,4 +47,4 @@ securitySchemes:
             A custom
 
 /users:
-    securedBy: [oauth_2_0, oauth_1_0]
+    securedBy: [oauth_2_0, oauth_1_0, null]

--- a/test/fixture/securedByCustomProps.raml
+++ b/test/fixture/securedByCustomProps.raml
@@ -67,3 +67,5 @@ securitySchemes:
         
 /test:
     securedBy: [null, {custom: { myKey: heLikesItNotSoMuch }}]
+    get:
+        securedBy: [null, {oauth_2_0: { scopes: [ADMINISTRATOR, USER] }}]

--- a/test/fixture/securedByCustomProps.raml
+++ b/test/fixture/securedByCustomProps.raml
@@ -1,0 +1,69 @@
+#%RAML 0.8
+title: Dropbox API
+version: 1
+baseUri: https://api.dropbox.com/{version}
+securitySchemes:
+    oauth_2_0:
+        description: |
+            Dropbox supports OAuth 2.0 for authenticating all API requests.
+        type: OAuth 2.0
+        describedBy:
+            headers:
+                Authorization:
+                    description: |
+                       Used to send a valid OAuth 2 access token. Do not use
+                       with the "access_token" query string parameter.
+                    type: string
+            queryParameters:
+                access_token:
+                    description: |
+                       Used to send a valid OAuth 2 access token. Do not use together with
+                       the "Authorization" header
+                    type: string
+            responses:
+                401:
+                    description: |
+                        Bad or expired token. This can happen if the user or Dropbox
+                        revoked or expired an access token. To fix, you should re-
+                        authenticate the user.
+                403:
+                    description: |
+                        Bad OAuth request (wrong consumer key, bad nonce, expired
+                        timestamp...). Unfortunately, re-authenticating the user won't help here.
+        settings:
+          authorizationUri: https://www.dropbox.com/1/oauth2/authorize
+          accessTokenUri: https://api.dropbox.com/1/oauth2/token
+          authorizationGrants: [ code, token ]
+    custom:
+        type: x-custom
+        describedBy:
+            headers:
+                Authorization:
+                    description: |
+                       Used to send a valid OAuth 2 access token. Do not use
+                       with the "access_token" query string parameter.
+                    type: string
+            queryParameters:
+                access_token:
+                    description: |
+                       Used to send a valid OAuth 2 access token. Do not use together with
+                       the "Authorization" header
+                    type: string
+            responses:
+                401:
+                    description: |
+                        Bad or expired token. This can happen if the user or Dropbox
+                        revoked or expired an access token. To fix, you should re-
+                        authenticate the user.
+                403:
+                    description: |
+                        Bad OAuth request (wrong consumer key, bad nonce, expired
+                        timestamp...). Unfortunately, re-authenticating the user won't help here.
+        settings:
+          myKey: heLikesIt
+/users:
+    get:
+        securedBy: [null, {oauth_2_0: { scopes: [ADMINISTRATOR] }}]
+        
+/test:
+    securedBy: [null, {custom: { myKey: heLikesItNotSoMuch }}]

--- a/test/fixture/tree/schema.json
+++ b/test/fixture/tree/schema.json
@@ -3,6 +3,6 @@
   "type": "array",
   "description": "A list of songs",
   "items": {
-    "$ref": "song.json"
+    "$ref": "../song.json"
   }
 }


### PR DESCRIPTION
**The Problem**
My 1.3.0 release had a bug that made it so that when two method based securedBys exist with custom settings, the first one parsed would overwrite the root settings data for the security descriptor. Thus, when checking the settings data on the second method, you could only retrieve values specified by the first method, and couldn't retrieve the default values when the second method didn't define any custom settings.
