### PR TITLE
Enhance SymfonyRouteFormatter to know about uriParameters

### DIFF
--- a/src/ApiDefinition.php
+++ b/src/ApiDefinition.php
@@ -627,7 +627,7 @@ class ApiDefinition implements ArrayInstantiationInterface
      *
      * @param \Raml\Resource[] $resources
      *
-     * @return array
+     * @return array[BasicRoute]
      */
     private function getMethodsAsArray(array $resources)
     {
@@ -645,10 +645,10 @@ class ApiDefinition implements ArrayInstantiationInterface
                     $path,
                     $protocols,
                     $method->getType(),
+                    $resource->getUriParameters(),
                     $resource->getMethod($method->getType())
                 );
             }
-
 
             $all = array_merge_recursive($all, $this->getMethodsAsArray($resource->getResources()));
         }

--- a/src/RouteFormatter/BasicRoute.php
+++ b/src/RouteFormatter/BasicRoute.php
@@ -6,6 +6,11 @@ use \Raml\Method;
 
 class BasicRoute
 {
+    /**
+     * The base URL for the route
+     *
+     * @var string
+     */
     private $baseUrl;
 
     /**
@@ -15,6 +20,11 @@ class BasicRoute
      */
     private $uri;
 
+    /**
+     * The protocol(s) of the routes
+     *
+     * @var array
+     */
     private $protocols;
 
     /**
@@ -24,6 +34,13 @@ class BasicRoute
      * @var string
      */
     private $type;
+
+    /**
+     * Any uri parameters of the route.
+     *
+     * @var array
+     */
+    private $uriParameters;
 
     /**
      * The Method definition
@@ -37,21 +54,30 @@ class BasicRoute
     /**
      * Create a new basic route
      *
+     * @param string $baseUrl
      * @param string $uri
+     * @param array $protocols
      * @param string $type
+     * @param array $uriParameters
      * @param Method $method
      */
-    public function __construct($baseUrl, $uri, $protocols, $type, Method $method)
+    public function __construct($baseUrl, $uri, $protocols, $type, $uriParameters, Method $method)
     {
         $this->baseUrl = $baseUrl;
         $this->uri = $uri;
         $this->protocols = $protocols;
-        $this->method = $method;
         $this->type = $type;
+        $this->uriParameters = $uriParameters;
+        $this->method = $method;
     }
 
     // --
 
+    /**
+     * Gets the base URL of the route
+     *
+     * @return string
+     */
     public function getBaseUrl()
     {
         return $this->baseUrl;
@@ -67,6 +93,11 @@ class BasicRoute
         return $this->uri;
     }
 
+    /**
+     * Gets the Protocols of the route
+     *
+     * @return array
+     */
     public function getProtocols()
     {
         return $this->protocols;
@@ -80,6 +111,16 @@ class BasicRoute
     public function getType()
     {
         return $this->type;
+    }
+
+    /**
+     * Gets the URI parameters of the route
+     *
+     * @return array
+     */
+    public function getUriParameters()
+    {
+        return $this->uriParameters;
     }
 
     /**


### PR DESCRIPTION
As the title, this pull request beefs up the `SymfonyRouteFormatter` so that it's able to push through information about parameters and their default values to the `Route` objects.

There are also minor fixes to PHP Doc