### PR TITLE
Force resolving parsed filename to a full path and other fixes

### DIFF
--- a/src/Body.php
+++ b/src/Body.php
@@ -185,7 +185,7 @@ class Body implements BodyInterface, ArrayInstantiationInterface
     /**
      * Get the list of examples
      *
-     * @return string
+     * @return string[]
      */
     public function getExamples()
     {

--- a/src/NamedParameter.php
+++ b/src/NamedParameter.php
@@ -546,6 +546,16 @@ class NamedParameter implements ArrayInstantiationInterface
     }
 
     /**
+     * Get all examples
+     *
+     * @return string[]
+     */
+    public function getExamples()
+    {
+        return $this->examples;
+    }
+
+    /**
      * Set the example
      *
      * @param string $example

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -186,6 +186,8 @@ class Parser
      */
     public function parse($fileName)
     {
+        $fileName = realpath($fileName);
+        
         if (!is_file($fileName)) {
             throw new FileNotFoundException($fileName);
         }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -177,19 +177,19 @@ class Parser
     /**
      * Parse a RAML spec from a file
      *
-     * @param string $fileName
+     * @param string $rawFileName
      *
      * @throws FileNotFoundException
      * @throws RamlParserException
      *
      * @return \Raml\ApiDefinition
      */
-    public function parse($fileName)
+    public function parse($rawFileName)
     {
-        $fileName = realpath($fileName);
+        $fileName = realpath($rawFileName);
         
         if (!is_file($fileName)) {
-            throw new FileNotFoundException($fileName);
+            throw new FileNotFoundException($rawFileName);
         }
 
         $rootDir = dirname($fileName);

--- a/src/Response.php
+++ b/src/Response.php
@@ -55,6 +55,7 @@ class Response implements ArrayInstantiationInterface
     public function __construct($statusCode)
     {
         $this->statusCode = (int) $statusCode;
+        $this->bodyList = [];
     }
 
     /**

--- a/src/Response.php
+++ b/src/Response.php
@@ -123,6 +123,16 @@ class Response implements ArrayInstantiationInterface
     }
 
     /**
+     * Returns the list of bodies for this response type.
+     *
+     * @return BodyInterface[]
+     */
+    public function getBodies()
+    {
+        return $this->bodyList;
+    }
+
+    /**
      * Returns all supported types in response
      *
      * @return array


### PR DESCRIPTION
This sets the rootDir variable correctly and avoids a problem when you're trying to do external JSON schema references like `{ "$ref": "shared/response.json#/definitions/response" }`.

Otherwise, when you pass a relative path to `Parser::parse` (such as `schema/api.raml`) the resulting JSON schema path for `shared/response.json` is `file::schema/shared/response.json`.