### PR TITLE
Fix to how schema parsers are fed source URI.

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -317,7 +317,7 @@ class Parser
                     if (in_array($key, array_keys($this->schemaParsers))) {
                         $schemaParser = $this->schemaParsers[$key];
                         $fileDir = $this->getCachedFilePath($value['schema']);
-                        $schemaParser->setSourceUri('file:' . ($fileDir ? $fileDir : $rootDir). DIRECTORY_SEPARATOR);
+                        $schemaParser->setSourceUri('file:' . ($fileDir ? $fileDir : $rootDir . DIRECTORY_SEPARATOR));
                         $value['schema'] = $schemaParser->createSchemaDefinition($value['schema']);
                     } else {
                         throw new InvalidSchemaTypeException($key);

--- a/test/ParseTest.php
+++ b/test/ParseTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use Raml\Schema\SchemaParserInterface;
-
 class ParseTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/test/ParseTest.php
+++ b/test/ParseTest.php
@@ -385,7 +385,7 @@ RAML;
     /** @test */
     public function shouldSetCorrectSourceUriOnSchemaParsers()
     {
-        $schemaParser = $this->getMock(SchemaParserInterface::class);
+        $schemaParser = $this->getMock('\Raml\Schema\SchemaParserInterface');
         $schemaParser->expects($this->any())->method('getCompatibleContentTypes')->willReturn([ 'application/json' ]);
         
         $schemaParser->expects($this->any())->method('setSourceUri')->withConsecutive(

--- a/test/ParseTest.php
+++ b/test/ParseTest.php
@@ -396,7 +396,7 @@ RAML;
             $schemaParser
         ]);
         
-        $parser->parse(__DIR__.'/fixture/includeIncludeSchema.raml');
+        $parser->parse(__DIR__.'/fixture/includeSchema.raml');
     }
     
     /** @test */

--- a/test/ParseTest.php
+++ b/test/ParseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Raml\Schema\SchemaParserInterface;
+
 class ParseTest extends PHPUnit_Framework_TestCase
 {
     /**
@@ -381,6 +383,23 @@ RAML;
     }
 
     /** @test */
+    public function shouldSetCorrectSourceUriOnSchemaParsers()
+    {
+        $schemaParser = $this->getMock(SchemaParserInterface::class);
+        $schemaParser->expects($this->any())->method('getCompatibleContentTypes')->willReturn([ 'application/json' ]);
+        
+        $schemaParser->expects($this->any())->method('setSourceUri')->withConsecutive(
+            [ 'file:'.__DIR__.'/fixture/songs.json' ]
+        );
+        
+        $parser = new \Raml\Parser([
+            $schemaParser
+        ]);
+        
+        $parser->parse(__DIR__.'/fixture/includeIncludeSchema.raml');
+    }
+    
+    /** @test */
     public function shouldThrowErrorIfEmpty()
     {
         $this->setExpectedException('Exception', 'RAML file appears to be empty');
@@ -418,7 +437,7 @@ RAML;
         $resource = $simpleRaml->getResourceByUri('/songs');
         $method = $resource->getMethod('get');
         $response = $method->getResponse(200);
-
+        
         $body = $response->getBodyByType('application/vnd.api-v1+json');
         $schema = $body->getSchema();
 

--- a/test/fixture/includeIncludeSchema.raml
+++ b/test/fixture/includeIncludeSchema.raml
@@ -1,0 +1,7 @@
+#%RAML 0.8
+
+title: World Music API Root
+baseUri: http://example.api.com/{version}
+version: v1
+
+/api: !include includeSchema.raml

--- a/test/fixture/includeIncludeSchema.raml
+++ b/test/fixture/includeIncludeSchema.raml
@@ -1,7 +1,0 @@
-#%RAML 0.8
-
-title: World Music API Root
-baseUri: http://example.api.com/{version}
-version: v1
-
-/api: !include includeSchema.raml


### PR DESCRIPTION
This one took a bit of work.

RAML !include'd schemas are resolved simply by replacing their contents with contents of referenced files. JSON-Schema references, however are resolved by separate parsers which can rely on relative paths. For example, a RAML file may refer to `foo/bar.json` which in turn contains a reference to `../baz.json`. `foo/bar.json` needs no know that it's working from `foo/` to know what to resolve `../baz.json` into.

The problem arises, however, when !included RAML files refer via to relative paths to JSON-Schema files that refer to relative paths. The JSON-Schema loader is being fed the directory the main RAML file was included from, instead of the path of the _included_ RAML file the JSON schema is being referenced from.

This path fixes it in a somewhat crude way. I don't see a better way to do it without re-engineering how RAML references are resolved.