### PR TITLE
apiDefinition::getRessourceByPath + check var existence and type in some places

### DIFF
--- a/src/ApiDefinition.php
+++ b/src/ApiDefinition.php
@@ -286,6 +286,37 @@ class ApiDefinition implements ArrayInstantiationInterface
         return $potentialResource;
     }
 
+    /**
+     * Get a resource by a path
+     *
+     * @param string $path
+     *
+     * @throws InvalidKeyException
+     *
+     * @return \Raml\Resource
+     */
+    public function getResourceByPath($path)
+    {
+        // get rid of everything after the ?
+        $uri = strtok($uri, '?');
+
+        $potentialResource = null;
+
+        $resources = $this->getResourcesAsArray($this->resources);
+        foreach ($resources as $resource) {
+            if ($uri === $resource->getUri()) {
+                $potentialResource = $resource;
+            }
+        }
+
+        if (!$potentialResource) {
+            // we never returned so throw exception
+            throw new ResourceNotFoundException($uri);
+        }
+
+        return $potentialResource;
+    }
+
 
     /**
      * Returns all the resources as a URI, essentially documenting the entire API Definition.

--- a/src/ApiDefinition.php
+++ b/src/ApiDefinition.php
@@ -298,20 +298,20 @@ class ApiDefinition implements ArrayInstantiationInterface
     public function getResourceByPath($path)
     {
         // get rid of everything after the ?
-        $uri = strtok($uri, '?');
+        $path = strtok($path, '?');
 
         $potentialResource = null;
 
         $resources = $this->getResourcesAsArray($this->resources);
         foreach ($resources as $resource) {
-            if ($uri === $resource->getUri()) {
+            if ($path === $resource->getUri()) {
                 $potentialResource = $resource;
             }
         }
 
         if (!$potentialResource) {
             // we never returned so throw exception
-            throw new ResourceNotFoundException($uri);
+            throw new ResourceNotFoundException($path);
         }
 
         return $potentialResource;

--- a/src/ApiDefinition.php
+++ b/src/ApiDefinition.php
@@ -269,21 +269,14 @@ class ApiDefinition implements ArrayInstantiationInterface
         // get rid of everything after the ?
         $uri = strtok($uri, '?');
 
-        $potentialResource = null;
-
         $resources = $this->getResourcesAsArray($this->resources);
         foreach ($resources as $resource) {
             if ($resource->matchesUri($uri)) {
-                $potentialResource = $resource;
+                return $resource;
             }
         }
-
-        if (!$potentialResource) {
-            // we never returned so throw exception
-            throw new ResourceNotFoundException($uri);
-        }
-
-        return $potentialResource;
+        // we never returned so throw exception
+        throw new ResourceNotFoundException($uri);
     }
 
     /**
@@ -300,21 +293,14 @@ class ApiDefinition implements ArrayInstantiationInterface
         // get rid of everything after the ?
         $path = strtok($path, '?');
 
-        $potentialResource = null;
-
         $resources = $this->getResourcesAsArray($this->resources);
         foreach ($resources as $resource) {
             if ($path === $resource->getUri()) {
-                $potentialResource = $resource;
+                return $resource;
             }
         }
-
-        if (!$potentialResource) {
-            // we never returned so throw exception
-            throw new ResourceNotFoundException($path);
-        }
-
-        return $potentialResource;
+        // we never returned so throw exception
+        throw new ResourceNotFoundException($path);
     }
 
 

--- a/src/Method.php
+++ b/src/Method.php
@@ -137,13 +137,15 @@ class Method implements ArrayInstantiationInterface
 
         if (isset($data['body'])) {
             foreach ($data['body'] as $key => $bodyData) {
-                if (in_array($key, WebFormBody::$validMediaTypes)) {
-                    $body = WebFormBody::createFromArray($key, $bodyData);
-                } else {
-                    $body = Body::createFromArray($key, $bodyData);
-                }
+                if (is_array($bodyData)) {
+                    if (in_array($key, WebFormBody::$validMediaTypes)) {
+                        $body = WebFormBody::createFromArray($key, $bodyData);
+                    } else {
+                        $body = Body::createFromArray($key, $bodyData);
+                    }
 
-                $method->addBody($body);
+                    $method->addBody($body);
+                }
             }
         }
 

--- a/src/WebFormBody.php
+++ b/src/WebFormBody.php
@@ -62,9 +62,11 @@ class WebFormBody extends NamedParameter implements BodyInterface, ArrayInstanti
     {
         $webFormBody = new static($key);
 
-        if ($data['formParameters']) {
+        if (isset($data['formParameters'])) {
             foreach ($data['formParameters'] as $namedParam => $namedParamData) {
-                $webFormBody->addParameter(NamedParameter::createFromArray($namedParam, $namedParamData));
+                if (is_array($namedParamData)) {
+                    $webFormBody->addParameter(NamedParameter::createFromArray($namedParam, $namedParamData));
+                }
             }
         }
 


### PR DESCRIPTION
* added apiDefinition::getRessourceByPath to grab resource from the route path
* added check to method::createFromArray to make sure body data is an array (in case of poorly written but still correct RAML)
* use of isset instead of plain check in webFormBody::createFromArray (in case of poorly written but still correct RAML) to avoid fatal error