### PR TITLE
Nested resources uriParams

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -163,10 +163,15 @@ class Resource implements ArrayInstantiationInterface
 
         foreach ($data as $key => $value) {
             if (strpos($key, '/') === 0) {
+                $value = $value ?: [];
+                if (isset($data['uriParameters'])) {
+                    $currentParameters = isset($value['uriParameters']) ? $value['uriParameters'] : [];
+                    $value['uriParameters'] = array_merge($currentParameters, $data['uriParameters']);
+                }
                 $resource->addResource(
                     Resource::createFromArray(
                         $uri.$key,
-                        $value ?: [],
+                        $value,
                         $apiDefinition
                     )
                 );

--- a/test/NamedParameters/UriParameterTest.php
+++ b/test/NamedParameters/UriParameterTest.php
@@ -60,4 +60,36 @@ RAML;
         $resource = $apiDef->getResourceByUri('/user/alec');
         $this->assertInstanceOf('\Raml\Resource', $resource);
     }
+
+    /** @test */
+    public function shouldPassUriParametersFromParentToSub()
+    {
+        $raml = <<<RAML
+#%RAML 0.8
+title: User API
+version: 1.0
+
+/base/{param1}:
+  uriParameters:
+    param1:
+      type: string
+
+  /sub/{param2}:
+    uriParameters:
+      param2:
+        type: string        
+RAML;
+
+        $apiDef = $this->parser->parseFromString($raml, '');
+
+        $resource = $apiDef->getResourceByPath("/base/{param1}/sub/{param2}");
+        $this->assertInstanceOf('\Raml\Resource', $resource);
+
+        $uriParameters = $resource->getUriParameters();
+
+        $this->assertCount(2, $uriParameters, "should contain 2 uri parameters");
+
+        $this->assertArrayHasKey('param1', $uriParameters, 'should contain uri parameter from parent');
+        $this->assertArrayHasKey('param2', $uriParameters, 'should contain uri parameter from sub');
+    }
 }


### PR DESCRIPTION
In nested resources it is impossible to access parent resource uriParams definition. This patch propagates Resource uriParams definition to all subresources.
