### PR TITLE
Prevent passing file paths to Parser::parseRamlString

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -531,7 +531,7 @@ class Parser
 
             // RAML and YAML files are always parsed
             $fileData = $this->parseRamlString(
-                $fullPath,
+                file_get_contents($fullPath),
                 $rootDir
             );
             $fileData = $this->includeAndParseFiles($fileData, $rootDir);


### PR DESCRIPTION
Currently it works because Yaml::parse has a compatibility check for this, but is deprecated and will be removed in the future.
