### PR TITLE
A method can override an API's protocols value

### DIFF
--- a/src/Method.php
+++ b/src/Method.php
@@ -341,7 +341,7 @@ class Method implements ArrayInstantiationInterface, MessageSchemaInterface
             throw new \InvalidArgumentException(sprintf('"%s" is not a valid protocol', $protocol));
         }
 
-        if (in_array($protocol, $this->protocols)) {
+        if (in_array($protocol, $this->protocols) === false) {
             $this->protocols[] = $protocol;
         }
     }

--- a/test/MethodTest.php
+++ b/test/MethodTest.php
@@ -59,10 +59,10 @@ class MethodTest extends PHPUnit_Framework_TestCase
                     200 => [
                         'body' => [
                             'text/xml' => ['description' => 'xml body'],
-                            'text/txt' => ['description' => 'plain text']
+                            'text/txt' => ['description' => 'plain text'],
                         ],
                         'description' => 'A dummy response',
-                        'headers' => []
+                        'headers' => [],
                     ]
                 ]
             ],
@@ -105,7 +105,7 @@ class MethodTest extends PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', $method->getProtocols());
         $this->assertCount(1, $method->getProtocols());
-        $this->assertSame(array('HTTP'), $method->getProtocols());
+        $this->assertSame(['HTTP'], $method->getProtocols());
     }
 
     /** @test */
@@ -118,16 +118,16 @@ class MethodTest extends PHPUnit_Framework_TestCase
             'get',
             [
                 'description' => 'A dummy method',
-                'protocols' => ['HTTP','HTTPS']
+                'protocols' => ['HTTP', 'HTTPS'],
             ],
             $apiDefinition
         );
 
         $this->assertInternalType('array', $method->getProtocols());
         $this->assertCount(2, $method->getProtocols());
-        $this->assertSame(array(
+        $this->assertSame([
             'HTTP',
-            'HTTPS'
-        ), $method->getProtocols());
+            'HTTPS',
+        ], $method->getProtocols());
     }
 }

--- a/test/MethodTest.php
+++ b/test/MethodTest.php
@@ -88,4 +88,46 @@ class MethodTest extends PHPUnit_Framework_TestCase
         $method = \Raml\Method::createFromArray('get', [], $apiDefinition);
         $this->assertEquals([], $method->getQueryParameters());
     }
+
+    /** @test */
+    public function shouldGetGlobalProtocols()
+    {
+        $parser = new \Raml\Parser();
+        $apiDefinition = $parser->parse(__DIR__.'/fixture/protocols/noProtocolSpecified.raml');
+
+        $method = \Raml\Method::createFromArray(
+            'get',
+            [
+                'description' => 'A dummy method',
+            ],
+            $apiDefinition
+        );
+
+        $this->assertInternalType('array', $method->getProtocols());
+        $this->assertCount(1, $method->getProtocols());
+        $this->assertSame(array('HTTP'), $method->getProtocols());
+    }
+
+    /** @test */
+    public function shouldGetOverrideProtocols()
+    {
+        $parser = new \Raml\Parser();
+        $apiDefinition = $parser->parse(__DIR__.'/fixture/protocols/noProtocolSpecified.raml');
+
+        $method = \Raml\Method::createFromArray(
+            'get',
+            [
+                'description' => 'A dummy method',
+                'protocols' => ['HTTP','HTTPS']
+            ],
+            $apiDefinition
+        );
+
+        $this->assertInternalType('array', $method->getProtocols());
+        $this->assertCount(2, $method->getProtocols());
+        $this->assertSame(array(
+            'HTTP',
+            'HTTPS'
+        ), $method->getProtocols());
+    }
 }


### PR DESCRIPTION
From RAML documentation: _"A method can override an API's protocols value for that single method by setting a different value for the fields."_  
source: https://github.com/raml-org/raml-spec/blob/master/versions/raml-08/raml-08.md#protocols-1

For the current version it's not working and this PR fix that.